### PR TITLE
Validate refactor

### DIFF
--- a/Jupiter/insert.py
+++ b/Jupiter/insert.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
 
         # Instantiate the Validator
         validator = Validation(df)
-        validator.validate()
+        validator.validateBeforeTransform()
 
         validated_df = validator.get_dataframe()
 

--- a/Jupiter/subLoop.py
+++ b/Jupiter/subLoop.py
@@ -75,7 +75,7 @@ def validateTransformLoad(file_path):
 
         # Instantiate the Validator
         validator = Validation(df)
-        validator.validate()
+        validator.validateBeforeTransform()
 
         validated_df = validator.get_dataframe()
 

--- a/Milestone2/insert.py
+++ b/Milestone2/insert.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
 
         # Instantiate the Validator
         validator = Validation(df)
-        validator.validate()
+        validator.validateBeforeTransform()
 
         validated_df = validator.get_dataframe()
 

--- a/Milestone2/subLoop.py
+++ b/Milestone2/subLoop.py
@@ -75,7 +75,7 @@ def validateTransformLoad(file_path):
 
         # Instantiate the Validator
         validator = Validation(df)
-        validator.validate()
+        validator.validateBeforeTransform()
 
         validated_df = validator.get_dataframe()
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # data-eg-chat
 Repo for any ccode that we might need
+
+# Useful commands:
+
+For a new cloned repo:
+1. Create a virtual python environment, make sure its name is env for auto scheduling: 'python -m venv env'
+2. Run the virtual env: 'source env/bin/activate'
+3. While virtual env is running: 'pip install google-cloud-pubsub'
+
+


### PR DESCRIPTION
- Removes rows with 'None' lat/long values. More consistent than interpolating. We still interpolate for any values found outside the range of Portland busses.
- refactor validate to validateBeforeTransform, and added validateAfterTransform. These should work according to the transformations now.